### PR TITLE
added activate extension command explicitly for firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,9 @@
       "storage"
     ],
     "commands": {
+      "_execute_browser_action": {
+        "description": "Activate extension"
+      },
       "split-up": {
         "description": "Split to separate window!"
       }


### PR DESCRIPTION
Hi again, so coming from my previous PR https://github.com/onaralili/SplitUp/pull/43. I thought the activate extension shortcut would be available in Firefox just like Chrome. That is not the case. It has to be explicitly added to the manifest file.

I have done that and tested on Firefox ( learned about `about:debugging`! ) and Chrome.

Would appreciate one more merge and publish to the addon store. 

Thanks! :)